### PR TITLE
Kuvien diffaus huomioimaan negatiiviset arvot oikein

### DIFF
--- a/src/kahvikamera.py
+++ b/src/kahvikamera.py
@@ -15,7 +15,7 @@ def sendImageToServer():
 
 def mse(img1, img2):
    h, w = img1.shape
-   diff = cv2.subtract(img2, img1)
+   diff = img1 - img2
    err = np.sum(diff**2)
    mse = err/(float(h*w))
    return mse


### PR DESCRIPTION
`mse()`:ssä kuvien diffaus oli alunperin muodossa:

`diff = cv2.subtract(img1, img2)`

Jossa ongelmaksi muodostui että kun yöllä pimeässä `img1` päätyy kokonaan mustaksi kuvaksi tulee MSE:n arvoksi aina nollaa koska `subtract()`:n tulos on väkisin positiivista. Eka purkkakorjaus oli muotoa

`diff = cv2.subtract(img2, img1)`

Jolla on pienempi riski ajautua jumiin mutta jos joku osoittaa taskulampulla kameraan niin että saadaan kokonaan valkoinen kuva jää systeemi todennäköisesti samalla tapaa jumiin. 

Googlailu paljasti että `cv2.subtract()` hoitaa negatiiviset arvot käyttäjän puolesta, kun toivottu lopputulos on se että negatiivisia arvoja nimenomaan ei hoideta, ja tämä saadaan aikaan yksinkertaisesti käyttämällä kuvamatriisien miinusta. Päivitin kattilan koodin toimimaan näin ja ainakin n. 20 sekunnin tarkkailujakson ja kerran kahvipannun nostamisen jälkeen kaikki näyttää _toimivan™_.

TODO: Pitääkö MSE:n maagista raja-arvoa 5 nostaa sillä nyt oikein toimiessa negatiiviseksi erottuvat pikselitkin huomioidaan? Nyt tätä kirjoittaessa kun keitin on koskematta antaa arvoksi n. 4.0-4.5 joten ei räpsi turhia kuvia, mutta esim. kohinaisemmissa valaistusolosuhteissa saattaa nyt helpommin mennä yli?